### PR TITLE
Change dependency to GPS Advertising Package

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -39,8 +39,6 @@
     <repo>https://github.com/praves77/cordova-plugin-android-idfa.git</repo>
     <issue>https://github.com/praves77/cordova-plugin-android-idfa/issues</issue>
 
-    <dependency id="com.google.play.services" />
-
     <js-module src="www/androidIDFA.js" name="androidIDFA">
         <!--<clobbers target="androidIDFA" />-->
         <merges target="androidIDFA" />
@@ -58,6 +56,8 @@
             <param name="android-package" value="com.praves.cordova.android.idfa.AndroidIDFA" />
         </feature>
     </config-file>
+    
+    <framework src="com.google.android.gms:play-services-ads:+" />
 
 </platform> 
 


### PR DESCRIPTION
As the Google Play Services whole package is a very big package (that goes well above the dreaded 65K method limit) and you can only import only the necessary ones, we are replacing the dependency to `com.google.android.gms:play-services-ads:+`.

Here is the explanation from Google : https://developers.google.com/android/guides/setup#split
