### PR TITLE
Update plugin

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "url": "git+https://github.com/praves77/cordova-plugin-android-idfa.git"
   },
   "dependencies": {
-    "com.google.play.services": "*"
+    "cordova-plugin-googleplayservices": "*"
   },
   "keywords": [
     "cordova",

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "url": "git+https://github.com/praves77/cordova-plugin-android-idfa.git"
   },
   "dependencies": {
-    "cordova-plugin-googleplayservices": "*"
+    "com.google.playservices": "*"
   },
   "keywords": [
     "cordova",

--- a/plugin.xml
+++ b/plugin.xml
@@ -56,10 +56,10 @@
             <param name="android-package" value="com.praves.cordova.android.idfa.AndroidIDFA" />
         </feature>
     </config-file>
-    
-    <framework src="com.google.android.gms:play-services-ads:+" />
 
-</platform> 
+    <framework src="com.google.android.gms:play-services-ads:11.0.1" />
+
+</platform>
 
 <!-- ios-specific elements -->
 <platform name="ios">


### PR DESCRIPTION
These updates should be made to run on latest Google Play Services.

Without these changes there are issues building with phonegap-plugin-push as the dependencies have conflicts.