### PR TITLE
Replace play-services-ads dep with play-services-ads-identifier

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -57,7 +57,7 @@
         </feature>
     </config-file>
     
-    <framework src="com.google.android.gms:play-services-ads:+" />
+    <framework src="com.google.android.gms:play-services-ads-identifier:+" />
 
 </platform> 
 


### PR DESCRIPTION
As of v17.0.0 of the play-services-ads library there is an
additional requirement to specify com.google.android.gms.ads.APPLICATION_ID
in the AndroidManifest.xml:

https://stackoverflow.com/questions/25061107/advertisingidclient-without-google-play-services

This plugin actually only needs play-services-ads-identifier in
order to get an advertising ID, so if we make our dependencies
more precise we can avoid this unnecessary requirement.